### PR TITLE
Update preset-ERC1155

### DIFF
--- a/packages/snfoundry/contracts/Scarb.toml
+++ b/packages/snfoundry/contracts/Scarb.toml
@@ -12,3 +12,7 @@ openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", ta
 
 [[target.starknet-contract]]
 casm = true
+
+
+[tool.fmt]
+sort-module-level-items = true

--- a/packages/snfoundry/contracts/src/lib.cairo
+++ b/packages/snfoundry/contracts/src/lib.cairo
@@ -3,7 +3,7 @@ mod simpleStorage;
 mod vote;
 mod challenge0;
 mod challenge1;
-mod challenge2;
+mod presetERC1155;
 mod challenge3;
 
 use starknet::ContractAddress;

--- a/packages/snfoundry/contracts/src/presetERC1155.cairo
+++ b/packages/snfoundry/contracts/src/presetERC1155.cairo
@@ -1,5 +1,6 @@
 #[starknet::contract]
-mod Challenge2 {
+mod PresetERC1155 {
+    use core::num::traits::zero::Zero;
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::token::erc1155::ERC1155Component;
     use starknet::ContractAddress;
@@ -13,8 +14,7 @@ mod Challenge2 {
     #[abi(embed_v0)]
     impl ERC1155MetadataURIImpl =
         ERC1155Component::ERC1155MetadataURIImpl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC1155Camel = ERC1155Component::ERC1155CamelImpl<ContractState>;
+
     impl ERC1155InternalImpl = ERC1155Component::InternalImpl<ContractState>;
 
     // SRC5
@@ -47,8 +47,19 @@ mod Challenge2 {
         values: Span<u256>
     ) {
         self.erc1155.initializer(base_uri);
-        self
-            .erc1155
-            .batch_mint_with_acceptance_check(recipient, token_ids, values, array![].span());
+        self.batch_mint(recipient, token_ids, values); //unsafe_batch_mint()
+    }
+
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        fn batch_mint(
+            ref self: ContractState,
+            recipient: ContractAddress,
+            token_ids: Span<u256>,
+            values: Span<u256>
+        ) {
+            assert(recipient.is_non_zero(), ERC1155Component::Errors::INVALID_RECEIVER);
+            self.erc1155.update(Zero::zero(), recipient, token_ids, values);
+        }
     }
 }

--- a/packages/snfoundry/scripts_js/deploy.js
+++ b/packages/snfoundry/scripts_js/deploy.js
@@ -156,16 +156,16 @@ const deployScript = async () => {
   //   "Challenge1"
   // );
 
-  // await deployContract(
-  //   {
-  //     base_uri: CallData.byteArrayFromString("https://example.com/"),
-  //     // recipient:
-  //     //   "0x06072Bb27d275a0bC1deBf1753649b8721CF845B681A48443Ac46baF45769f8E",
-  //     // token_ids: 2,
-  //     // values: 100,
-  //   },
-  //   "Challenge2"
-  // );
+  await deployContract(
+    {
+      base_uri: "https://example.com/",
+      recipient:
+        "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+      token_ids: [2],
+      values: [100],
+    },
+    "PresetERC1155"
+  );
 
   // await deployContract(
   //   {


### PR DESCRIPTION
# Task name here

Fixes #relevant-issue-here

## Types of change

- [x] Feature

## Comments (optional)
This is a preset-ERC1155 based on [OZ](https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.10.0/src/presets/erc1155.cairo). The difference here is that we use `batch_mint`(unsafe) instead of `batch_mint_with_acceptance_check()`