### PR TITLE
devops(demo): support scaffol-stark-demo workflow

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -1,0 +1,63 @@
+name: scaffol-stark-demo workflow
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+    paths:
+      - 'packages/nextjs/**'
+
+jobs:
+  version-bump-nextjs:
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Checkout Source Repository
+        uses: actions/checkout@v4
+        with:
+          repository: oceanlvr/scaffold-stark-2
+          path: source_repo
+
+      - name: Modify scaffoldConfig in Source Repository
+        run: |
+          cd source_repo
+          sed -i 's/targetNetworks: \[chains.devnet\]/targetNetworks: \[chains.sepolia\]/' packages/nextjs/scaffold.config.ts
+          cat packages/nextjs/scaffold.config.ts
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: 'https://registry.yarnpkg.com'
+
+      - name: Deploy to vercel
+        if: success()
+        id: deploy
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          cd source_repo
+          yarn install
+          vercel link --yes --project $VERCEL_PROJECT_ID --token $VERCEL_TOKEN --scope $VERCEL_ORG_ID
+          vercel --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true --prod --token $VERCEL_TOKEN --scope $VERCEL_ORG_ID
+
+      - name: Notify Slack on Success
+        if: success()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "GitHub build result: ${{ job.status }}\nRepository Name: ${{ github.repository }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "GitHub build result: ${{ job.status }}\nRepository Name: ${{ github.repository }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -1,4 +1,4 @@
-name: scaffol-stark-demo workflow
+name: scaffold-stark-demo workflow
 
 on:
   pull_request:
@@ -49,7 +49,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "GitHub build result: ${{ job.status }}\nRepository Name: ${{ github.repository }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          slack-message: "GitHub deployed to vercel result: ${{ job.status }}\nRepository Name: ${{ github.repository }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
@@ -58,7 +58,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "GitHub build result: ${{ job.status }}\nRepository Name: ${{ github.repository }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          slack-message: "GitHub deployed to vercel result: ${{ job.status }}\nRepository Name: ${{ github.repository }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -15,7 +15,8 @@ jobs:
       - name: Checkout Source Repository
         uses: actions/checkout@v4
         with:
-          repository: oceanlvr/scaffold-stark-2
+          repository: Quantum3-Labs/scaffold-stark-2
+          token: ${{ secrets.ORG_GITHUB_TOKEN }}
           path: source_repo
 
       - name: Modify scaffoldConfig in Source Repository


### PR DESCRIPTION
# Task name here

Workflows / vercel deployment / version control

The final outcome is to have a sample website out of scaffold-stark repo. There are some ways this can be done, we can just add one more workflow to it. This is a simpler approach. 
Or we can have a public repository called scaffol-stark-demo, that is like a website sample out of Scaffold-stark.
Everytime there is an update on the main repo, the workflow should update another scaffol-stark-demo repo and run a workflow on it to deploy it to vercel. 

## Types of change

- [x] Feature
- [ ] Bug
- [ ] Enhancement

## Comments (optional)

I choose use env to control the deployed block chain network. It might lead to a bit unmaintainable.

every time we push code to `nextjs` folder on the master branch, it would trigger this pipeline to deploy a new nextjs app on vercel. (using sepolia net)