### PR TITLE
fix: clicking twice to open read

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { Abi } from "abi-wan-kanabi";
 import { Address } from "@starknet-react/chains";
 import {
@@ -38,7 +38,7 @@ export const ReadOnlyFunctionForm = ({
     functionName: abiFunction.name,
     abi: [...abi],
     args: inputValue ? inputValue.flat(Infinity) : [],
-    enabled: false,
+
     parseArgs: false,
     blockIdentifier: "pending" as BlockNumber,
   });
@@ -59,14 +59,14 @@ export const ReadOnlyFunctionForm = ({
     );
   });
 
-  const handleRead = () => {
+  const handleRead = useCallback(() => {
     const newInputValue = getParsedContractFunctionArgs(form, false);
     if (JSON.stringify(form) !== JSON.stringify(lastForm.current)) {
       setInputValue(newInputValue);
       lastForm.current = form;
     }
     refetch();
-  };
+  }, [form, refetch]);
 
   return (
     <div className="flex flex-col gap-3 py-5 first:pt-0 last:pb-1">

--- a/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
@@ -38,7 +38,7 @@ export const ReadOnlyFunctionForm = ({
     functionName: abiFunction.name,
     abi: [...abi],
     args: inputValue ? inputValue.flat(Infinity) : [],
-
+    enabled: Boolean(inputValue),
     parseArgs: false,
     blockIdentifier: "pending" as BlockNumber,
   });


### PR DESCRIPTION
# Task name here

Fixes #244 

## Types of change

- [ ] Feature
- [X] Bug
- [ ] Enhancement

## Comments (optional)

- Also optimized the callback `handleRead` with the `useCallback` hook
