### PR TITLE
fix: inconsistent behaviour of usescaffoldcontract

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
@@ -27,19 +27,8 @@ export const useScaffoldContract = <TContractName extends ContractName>({
     contract = new Contract(
       [...deployedContractData.abi],
       deployedContractData.address,
-      account || publicClient,
+      publicClient,
     );
-
-    // override call with our options
-    // TODO: remove if starknet has standardized parsers for extension wallets
-    const _call = contract.call;
-    contract.call = function (method, args, options) {
-      // TODO: incorporate parser id parseResponse is set to true
-      return _call.bind(this)(method, args, {
-        ...options,
-        parseResponse: false,
-      });
-    };
   }
 
   return {

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
@@ -14,7 +14,6 @@ export const useScaffoldContract = <TContractName extends ContractName>({
     useDeployedContractInfo(contractName);
 
   const { targetNetwork } = useTargetNetwork();
-  const { account } = useAccount();
   const publicNodeUrl = targetNetwork.rpcUrls.public.http[0];
 
   const publicClient = useMemo(() => {
@@ -27,7 +26,7 @@ export const useScaffoldContract = <TContractName extends ContractName>({
     contract = new Contract(
       [...deployedContractData.abi],
       deployedContractData.address,
-      account || publicClient,
+      publicClient,
     );
   }
 

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
@@ -14,6 +14,7 @@ export const useScaffoldContract = <TContractName extends ContractName>({
     useDeployedContractInfo(contractName);
 
   const { targetNetwork } = useTargetNetwork();
+  const { account } = useAccount();
   const publicNodeUrl = targetNetwork.rpcUrls.public.http[0];
 
   const publicClient = useMemo(() => {
@@ -26,8 +27,17 @@ export const useScaffoldContract = <TContractName extends ContractName>({
     contract = new Contract(
       [...deployedContractData.abi],
       deployedContractData.address,
-      publicClient,
+      account || publicClient,
     );
+
+    // override call with our options
+    const _call = contract.call;
+    contract.call = function (method, args, options) {
+      return _call.bind(this)(method, args, {
+        ...options,
+        parseResponse: false,
+      });
+    };
   }
 
   return {

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
@@ -31,8 +31,10 @@ export const useScaffoldContract = <TContractName extends ContractName>({
     );
 
     // override call with our options
+    // TODO: remove if starknet has standardized parsers for extension wallets
     const _call = contract.call;
     contract.call = function (method, args, options) {
+      // TODO: incorporate parser id parseResponse is set to true
       return _call.bind(this)(method, args, {
         ...options,
         parseResponse: false,


### PR DESCRIPTION
# Task name here

Fixes #243 

## Types of change

- [ ] Feature
- [X] Bug
- [ ] Enhancement

## Comments (optional)

- Added relevant TODOs for future tech debts
- Might need to incorporate own parser to emulate `parseResponse = true` behaviour
