### PR TITLE
refactor: use useScaffoldReadContract in ContractReadMethods

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/ContractReadMethods.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractReadMethods.tsx
@@ -11,8 +11,10 @@ import { ReadOnlyFunctionForm } from "./ReadOnlyFunctionForm";
 
 export const ContractReadMethods = ({
   deployedContractData,
+  contractName,
 }: {
   deployedContractData: Contract<ContractName>;
+  contractName: ContractName;
 }) => {
   if (!deployedContractData) {
     return null;
@@ -39,7 +41,7 @@ export const ContractReadMethods = ({
       {functionsToDisplay.map(({ fn }) => (
         <ReadOnlyFunctionForm
           abi={deployedContractData.abi as Abi}
-          contractAddress={deployedContractData.address}
+          contractName={contractName}
           abiFunction={fn}
           key={fn.name}
         />

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -117,6 +117,7 @@ export const ContractUI = ({
                 <ContractWriteMethods
                   deployedContractData={deployedContractData}
                   onChange={triggerRefreshDisplayVariables}
+                  contractName={contractName}
                 />
               </div>
             </div>

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -86,6 +86,7 @@ export const ContractUI = ({
             <ContractVariables // TODO : there is no contract variables on starknet
               refreshDisplayVariables={refreshDisplayVariables}
               deployedContractData={deployedContractData}
+              contractName={contractName}
             />
           </div>
         </div>

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -100,6 +100,7 @@ export const ContractUI = ({
               <div className="p-5 divide-y divide-secondary">
                 <ContractReadMethods
                   deployedContractData={deployedContractData}
+                  contractName={contractName}
                 />
               </div>
             </div>

--- a/packages/nextjs/app/debug/_components/contract/ContractVariables.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractVariables.tsx
@@ -1,10 +1,7 @@
 import { Abi } from "abi-wan-kanabi";
 import {
-  AbiFunction,
   Contract,
   ContractName,
-  GenericContract,
-  InheritedFunctions,
   getFunctionsByStateMutability,
 } from "~~/utils/scaffold-stark/contract";
 import { DisplayVariable } from "./DisplayVariable";
@@ -43,12 +40,10 @@ export const ContractVariables = ({
     <>
       {functionsToDisplay.map(({ fn }) => (
         <DisplayVariable
-          // abi={deployedContractData.abi as Abi}
           abiFunction={fn}
           contractName={contractName}
           key={fn.name}
           refreshDisplayVariables={refreshDisplayVariables}
-          //   inheritedFrom={inheritedFrom}
         />
       ))}
     </>

--- a/packages/nextjs/app/debug/_components/contract/ContractVariables.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractVariables.tsx
@@ -12,9 +12,11 @@ import { DisplayVariable } from "./DisplayVariable";
 export const ContractVariables = ({
   refreshDisplayVariables,
   deployedContractData,
+  contractName,
 }: {
   refreshDisplayVariables: boolean;
   deployedContractData: Contract<ContractName>;
+  contractName: ContractName;
 }) => {
   if (!deployedContractData) {
     return null;
@@ -41,9 +43,9 @@ export const ContractVariables = ({
     <>
       {functionsToDisplay.map(({ fn }) => (
         <DisplayVariable
-          abi={deployedContractData.abi as Abi}
+          // abi={deployedContractData.abi as Abi}
           abiFunction={fn}
-          contractAddress={deployedContractData.address}
+          contractName={contractName}
           key={fn.name}
           refreshDisplayVariables={refreshDisplayVariables}
           //   inheritedFrom={inheritedFrom}

--- a/packages/nextjs/app/debug/_components/contract/ContractWriteMethods.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractWriteMethods.tsx
@@ -9,9 +9,11 @@ import {
 export const ContractWriteMethods = ({
   onChange,
   deployedContractData,
+  contractName,
 }: {
   onChange: () => void;
   deployedContractData: Contract<ContractName>;
+  contractName: ContractName;
 }) => {
   if (!deployedContractData) {
     return null;
@@ -39,6 +41,7 @@ export const ContractWriteMethods = ({
           abiFunction={fn}
           onChange={onChange}
           contractAddress={deployedContractData.address}
+          contractName={contractName}
           //   inheritedFrom={inheritedFrom}
         />
       ))}

--- a/packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx
+++ b/packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx
@@ -25,7 +25,6 @@ export const DisplayVariable = ({
   contractName,
   abiFunction,
   refreshDisplayVariables,
-  // abi, //   inheritedFrom,
 }: DisplayVariableProps) => {
   const {
     data: result,

--- a/packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx
+++ b/packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx
@@ -4,39 +4,47 @@ import { useEffect } from "react";
 // import { InheritanceTooltip } from "./InheritanceTooltip";
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
 import { useAnimationConfig } from "~~/hooks/scaffold-stark";
-import { AbiFunction } from "~~/utils/scaffold-stark/contract";
+import { AbiFunction, ContractName } from "~~/utils/scaffold-stark/contract";
 import { Abi } from "abi-wan-kanabi";
 import { Address } from "@starknet-react/chains";
 import { useContractRead } from "@starknet-react/core";
 import { BlockNumber } from "starknet";
 import { displayTxResult } from "./utilsDisplay";
 import { useTheme } from "next-themes";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-stark/useScaffoldReadContract";
 
 type DisplayVariableProps = {
-  contractAddress: Address;
   abiFunction: AbiFunction;
   refreshDisplayVariables: boolean;
   //   inheritedFrom?: string;
-  abi: Abi;
+  // abi: Abi;
+  contractName: ContractName;
 };
 
 export const DisplayVariable = ({
-  contractAddress,
+  contractName,
   abiFunction,
   refreshDisplayVariables,
-  abi, //   inheritedFrom,
+  // abi, //   inheritedFrom,
 }: DisplayVariableProps) => {
   const {
     data: result,
     isLoading,
     isFetching,
     refetch,
-  } = useContractRead({
-    address: contractAddress,
+    error,
+  } = useScaffoldReadContract({
+    contractName,
+
+    // @ts-expect-error we do not know the specific function name, this is type-safe
     functionName: abiFunction.name,
-    abi: [...abi],
-    blockIdentifier: "pending" as BlockNumber, // TODO : notify when failed - add error
+    blockIdentifier: "pending" as BlockNumber,
   });
+
+  // TODO : notify when failed - add error (need ui)
+  useEffect(() => {
+    if (error) console.error({ error: error.stack });
+  }, [error]);
 
   const { showAnimation } = useAnimationConfig(result);
   const { resolvedTheme } = useTheme();

--- a/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
@@ -34,21 +34,12 @@ export const ReadOnlyFunctionForm = ({
   const [formErrorMessage, setFormErrorMessage] = useState<string | null>(null);
   const lastForm = useRef(form);
 
-  // const { isFetching, data, refetch } = useContractRead({
-  //   address: contractAddress,
-  //   functionName: abiFunction.name,
-  //   abi: [...abi],
-  //   args: inputValue ? inputValue.flat(Infinity) : [],
-  //   enabled: Boolean(inputValue),
-  //   parseArgs: false,
-  //   blockIdentifier: "pending" as BlockNumber,
-  // });
-
   const { isFetching, data, refetch } = useScaffoldReadContract({
     contractName,
-    functionName: abiFunction.name as any,
+    // @ts-expect-error we do not know the specific function name, this is type-safe
+    functionName: abiFunction.name,
     args: inputValue ? inputValue.flat(Infinity) : [],
-    enabled: Boolean(inputValue),
+    enabled: inputValue !== undefined,
     parseArgs: false,
     blockIdentifier: "pending" as BlockNumber,
   });

--- a/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
@@ -10,19 +10,20 @@ import {
   getParsedContractFunctionArgs,
   transformAbiFunction,
 } from "~~/app/debug/_components/contract";
-import { AbiFunction } from "~~/utils/scaffold-stark/contract";
+import { AbiFunction, ContractName } from "~~/utils/scaffold-stark/contract";
 import { BlockNumber } from "starknet";
 import { useContractRead } from "@starknet-react/core";
 import { ContractInput } from "./ContractInput";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-stark/useScaffoldReadContract";
 
 type ReadOnlyFunctionFormProps = {
-  contractAddress: Address;
+  contractName: ContractName;
   abiFunction: AbiFunction;
   abi: Abi;
 };
 
 export const ReadOnlyFunctionForm = ({
-  contractAddress,
+  contractName,
   abiFunction,
   abi,
 }: ReadOnlyFunctionFormProps) => {
@@ -33,10 +34,19 @@ export const ReadOnlyFunctionForm = ({
   const [formErrorMessage, setFormErrorMessage] = useState<string | null>(null);
   const lastForm = useRef(form);
 
-  const { isFetching, data, refetch } = useContractRead({
-    address: contractAddress,
-    functionName: abiFunction.name,
-    abi: [...abi],
+  // const { isFetching, data, refetch } = useContractRead({
+  //   address: contractAddress,
+  //   functionName: abiFunction.name,
+  //   abi: [...abi],
+  //   args: inputValue ? inputValue.flat(Infinity) : [],
+  //   enabled: Boolean(inputValue),
+  //   parseArgs: false,
+  //   blockIdentifier: "pending" as BlockNumber,
+  // });
+
+  const { isFetching, data, refetch } = useScaffoldReadContract({
+    contractName,
+    functionName: abiFunction.name as any,
     args: inputValue ? inputValue.flat(Infinity) : [],
     enabled: Boolean(inputValue),
     parseArgs: false,

--- a/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
@@ -1,14 +1,16 @@
+import { isCairoTuple } from "~~/utils/scaffold-stark";
 import {
   AbiEnum,
   AbiFunction,
   AbiParameter,
   AbiStruct,
   parseParamWithType,
+  stringToObjectTuple,
 } from "~~/utils/scaffold-stark/contract";
 /**
  * Generates a key based on function metadata
  */
-const getFunctionInputKey = (
+export const getFunctionInputKey = (
   functionName: string,
   input: AbiParameter,
   inputIndex: number,
@@ -17,7 +19,7 @@ const getFunctionInputKey = (
   return functionName + "_" + name + "_" + input.type;
 };
 
-const isJsonString = (str: string) => {
+export const isJsonString = (str: string) => {
   try {
     JSON.parse(str);
     return true;
@@ -26,7 +28,7 @@ const isJsonString = (str: string) => {
   }
 };
 
-const getInitialTupleFormState = (abiParameter: AbiStruct | AbiEnum) => {
+export const getInitialTupleFormState = (abiParameter: AbiStruct | AbiEnum) => {
   const initialForm: Record<string, any> = {};
 
   if (abiParameter.type === "struct") {
@@ -43,7 +45,7 @@ const getInitialTupleFormState = (abiParameter: AbiStruct | AbiEnum) => {
   return initialForm;
 };
 
-const getInitialFormState = (abiFunction: AbiFunction) => {
+export const getInitialFormState = (abiFunction: AbiFunction) => {
   const initialForm: Record<string, any> = {};
   if (!abiFunction.inputs) return initialForm;
   abiFunction.inputs.forEach((input, inputIndex) => {
@@ -53,7 +55,7 @@ const getInitialFormState = (abiFunction: AbiFunction) => {
   return initialForm;
 };
 
-const deepParseValues = (
+export const deepParseValues = (
   value: any,
   isRead: boolean,
   keyAndType?: any,
@@ -104,7 +106,7 @@ const deepParseValues = (
 /**
  * parses form input with array support
  */
-const getParsedContractFunctionArgs = (
+export const getParsedContractFunctionArgs = (
   form: Record<string, any>,
   isRead: boolean,
 ) => {
@@ -114,13 +116,13 @@ const getParsedContractFunctionArgs = (
   });
 };
 
-const adjustInput = (input: AbiParameter): AbiParameter => {
+export const adjustInput = (input: AbiParameter): AbiParameter => {
   return {
     ...input,
   };
 };
 
-const transformAbiFunction = (abiFunction: AbiFunction): AbiFunction => {
+export const transformAbiFunction = (abiFunction: AbiFunction): AbiFunction => {
   return {
     ...abiFunction,
     inputs: abiFunction.inputs.map((value) =>
@@ -129,11 +131,9 @@ const transformAbiFunction = (abiFunction: AbiFunction): AbiFunction => {
   };
 };
 
-export {
-  getFunctionInputKey,
-  isJsonString,
-  getInitialFormState,
-  getInitialTupleFormState,
-  getParsedContractFunctionArgs,
-  transformAbiFunction,
+// convert string input into starknet js objects (to mainly support odd inputs like tuples)
+// adding this 'redundant function' due to the unclarity of the parseParamsWithType function
+export const convertStringToInputInstance = (type: string = "", value: any) => {
+  if (type.includes("(")) return stringToObjectTuple(value, type);
+  return deepParseValues(value, false, type);
 };

--- a/packages/nextjs/utils/scaffold-stark/contract.ts
+++ b/packages/nextjs/utils/scaffold-stark/contract.ts
@@ -681,7 +681,7 @@ function objectToCairoTuple(obj: { [key: number]: any }, type: string): string {
   return `(${values})`;
 }
 
-function stringToObjectTuple(
+export function stringToObjectTuple(
   tupleString: string,
   paramType: string,
 ): { [key: number]: any } {


### PR DESCRIPTION
# Task name here

Fixes #229 

## Types of change

- [ ] Feature
- [ ] Bug
- [X] Enhancement

## Comments (optional)

Nice to have - use context API to prevent prop drilling on some cases
