### PR TITLE
fix: add workaround on wallet connectors to remove from localStorage

### DIFF
--- a/packages/nextjs/services/web3/connectors.tsx
+++ b/packages/nextjs/services/web3/connectors.tsx
@@ -1,4 +1,4 @@
-import { argent, braavos } from "@starknet-react/core";
+import { argent, braavos, InjectedConnector } from "@starknet-react/core";
 import { getTargetNetworks } from "~~/utils/scaffold-stark";
 import { BurnerConnector } from "./stark-burner/BurnerConnector";
 import scaffoldConfig from "~~/scaffold.config";
@@ -6,6 +6,17 @@ import scaffoldConfig from "~~/scaffold.config";
 const targetNetworks = getTargetNetworks();
 
 export const connectors = getConnectors();
+
+// workaround helper function to properly disconnect with removing local storage (prevent autoconnect infinite loop)
+function withDisconnectWrapper(connector: InjectedConnector) {
+  const connectorDisconnect = connector.disconnect;
+  const _disconnect = (): Promise<void> => {
+    localStorage.removeItem("lastUsedConnector");
+    return connectorDisconnect();
+  };
+  connector.disconnect = _disconnect.bind(connector);
+  return connector;
+}
 
 function getConnectors() {
   const { targetNetworks } = scaffoldConfig;
@@ -18,7 +29,7 @@ function getConnectors() {
     connectors.push(new BurnerConnector());
   }
 
-  return connectors.sort(() => Math.random() - 0.5);
+  return connectors.sort(() => Math.random() - 0.5).map(withDisconnectWrapper);
 }
 
 export const appChains = targetNetworks;


### PR DESCRIPTION
# Task name here

Fixes #256 
Fixes https://github.com/Quantum3-Labs/speedrunstark/issues/110

## Types of change

- [ ] Feature
- [X] Bug
- [ ] Enhancement

## Comments (optional)

- Note this is  a workaround that tampers with the `disconnect()` function of the connector. I've injected a local storage removal operation to clear local storage so that `useAutoConnect()` does not go in a infinite loop when it finds something stored.
- Should be able to resolve the issue in speedrunstark (https://github.com/Quantum3-Labs/speedrunstark/issues/110) as well @gianalarcon 

